### PR TITLE
Expand GitHub Actions triggers for broader CI/CD coverage

### DIFF
--- a/.github/workflows/gh-actions.yml
+++ b/.github/workflows/gh-actions.yml
@@ -3,6 +3,9 @@ name: Build, Test, and Deploy TOTUM to Azure Container App
 on:
   push:
     branches: [main]
+  pull_request:
+    branches: [main]
+  workflow_dispatch:
 
 env:
   AZURE_CONTAINER_REGISTRY: totum-bgcxfhgaa4e4cghw.azurecr.io


### PR DESCRIPTION
Updated gh-actions.yml to trigger workflows not only on pushes to the main branch, but also on pull requests targeting main and via manual workflow_dispatch. This enhances CI/CD by ensuring workflows run under more scenarios.